### PR TITLE
POR-10: Fix section spacing bug

### DIFF
--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -13,7 +13,7 @@ const Section = forwardRef<HTMLDivElement, SectionProps>(
       id={id}
       ref={ref}
       className={clsx(
-        { 'first:pt-24': overrideTopPadding },
+        { 'first:pt-24': !overrideTopPadding },
         'container text-primary py-8 last:pb-16'
       )}
     >


### PR DESCRIPTION
# Description

Fixed bug with the section component not having top padding. This was due to not inverting the overrideTopPadding prop value.

[https://kylegough.atlassian.net/browse/POR-10](https://kylegough.atlassian.net/browse/POR-10)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings