### PR TITLE
Fix timeline thickness consistency

### DIFF
--- a/src/components/TimelineNode/TimelineNode.tsx
+++ b/src/components/TimelineNode/TimelineNode.tsx
@@ -42,7 +42,7 @@ export const TimelineNode: React.FC<TimelineNodeProps> = ({
           <p className="text-xl">{title}</p>
           <p>{date}</p>
         </FadeIn>
-        <div className="h-px border border-timeline w-6 max-w-[12rem] grow"></div>
+        <div className="h-[2px] bg-timeline w-6 max-w-[12rem] grow"></div>
       </div>
       {align === 'left' && <div className='hidden md:block'></div>}
     </>

--- a/src/components/TimelineNode/__snapshots__/TimelineNode.test.tsx.snap
+++ b/src/components/TimelineNode/__snapshots__/TimelineNode.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`TimelineNode component renders 1`] = `
       </p>
     </div>
     <div
-      class="h-px border border-timeline w-6 max-w-[12rem] grow"
+      class="h-[2px] bg-timeline w-6 max-w-[12rem] grow"
     />
   </div>
   <div

--- a/src/pages/Home/__snapshots__/Home.test.tsx.snap
+++ b/src/pages/Home/__snapshots__/Home.test.tsx.snap
@@ -245,7 +245,7 @@ exports[`Home component renders 1`] = `
             </p>
           </div>
           <div
-            class="h-px border border-timeline w-6 max-w-[12rem] grow"
+            class="h-[2px] bg-timeline w-6 max-w-[12rem] grow"
           />
         </div>
         <div
@@ -284,7 +284,7 @@ exports[`Home component renders 1`] = `
             </p>
           </div>
           <div
-            class="h-px border border-timeline w-6 max-w-[12rem] grow"
+            class="h-[2px] bg-timeline w-6 max-w-[12rem] grow"
           />
         </div>
         <div
@@ -317,7 +317,7 @@ exports[`Home component renders 1`] = `
             </p>
           </div>
           <div
-            class="h-px border border-timeline w-6 max-w-[12rem] grow"
+            class="h-[2px] bg-timeline w-6 max-w-[12rem] grow"
           />
         </div>
         <div


### PR DESCRIPTION
# Description

There is a small visual bug with the timeline component on the homepage. For some devices the horizontal lines were hollow and the vertical lines were filled. This is due to setting background colour for the vertical lines but border for the horizontal lines. Originally this was unnoticed as on desktop devices the thickness of the lines obscures the hollowness.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings