### PR TITLE
Added Cloudflare rocket loader to script-src CSP header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const contentSecurityPolicy = `
   frame-ancestors 'self';
   img-src 'self' data:;
   object-src 'none';
-  script-src 'self' static.cloudflareinsights.com vitals.vercel-insights.com;
+  script-src 'self' static.cloudflareinsights.com ajax.cloudflare.com vitals.vercel-insights.com;
   script-src-attr 'none';
   connect-src 'self' cloudflareinsights.com vitals.vercel-insights.com;
   style-src 'self' https: 'unsafe-inline';


### PR DESCRIPTION
# Description

Enables Cloudflare rocket loader script in the CSP header `script-src` via the domain `ajax.cloudflare.com`.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings
