### PR TITLE
Disable CSP on non-prod environments

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,10 +29,10 @@ const securityHeaders = [
     key: 'Strict-Transport-Security',
     value: 'max-age=63072000; includeSubDomains; preload'
   },
-  {
+  ...(process.env.NODE_ENV === 'production' ? [{
     key: 'Content-Security-Policy',
     value: contentSecurityPolicy.replace(/\s{2,}/g, ' ').trim()
-  },
+  }] : []),
   // Disable all browser features.
   {
     key: 'Permissions-Policy',


### PR DESCRIPTION
# Description

Dev environment was not working due to the CSP header.
- Disable the CSP header on non-production environments.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings
