### PR TITLE
Screenshots use next/image

### DIFF
--- a/components/Carousel/Carousel.tsx
+++ b/components/Carousel/Carousel.tsx
@@ -20,7 +20,7 @@ export const Carousel: React.FC<CarouselProps> = ({
     return () => {
       window.clearInterval(carouselInterval.current as NodeJS.Timeout);
     };
-  }, []);
+  });
 
   const carouselNext = () =>
     setCarousel((carousel) => (carousel + 1) % carouselCount);

--- a/components/ImageModal/ImageModal.tsx
+++ b/components/ImageModal/ImageModal.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import React, { useState } from 'react';
 
 interface ImageModalProps {
@@ -14,14 +15,20 @@ export const ImageModal: React.FC<ImageModalProps> = ({ src, alt }) => {
 
   return (
     <>
-      <figure className="col-span-12 md:col-span-6 lg:col-span-4">
-        <img
-          loading="lazy"
+      <figure className="col-span-12 md:col-span-6 lg:col-span-4 relative">
+        <div
           onClick={openModal}
-          className="cursor-pointer border-2 border-link hover:border-link-hover"
-          src={src}
-          alt={alt}
-        />
+          className="cursor-pointer border-2 border-link hover:border-link-hover h-44 overflow-hidden"
+        >
+          <Image
+            src={src}
+            alt={alt}
+            objectFit="cover"
+            objectPosition="top"
+            width={400}
+            height={200}
+          />
+        </div>
         <figcaption className="my-2 text-sm text-center text-light font-thin">
           {alt}
         </figcaption>

--- a/components/ImageModal/__snapshots__/ImageModal.test.tsx.snap
+++ b/components/ImageModal/__snapshots__/ImageModal.test.tsx.snap
@@ -3,14 +3,34 @@
 exports[`ImageModal component renders 1`] = `
 <div>
   <figure
-    class="col-span-12 md:col-span-6 lg:col-span-4"
+    class="col-span-12 md:col-span-6 lg:col-span-4 relative"
   >
-    <img
-      alt="Test Caption"
-      class="cursor-pointer border-2 border-link hover:border-link-hover"
-      loading="lazy"
-      src="/#"
-    />
+    <div
+      class="cursor-pointer border-2 border-link hover:border-link-hover h-44 overflow-hidden"
+    >
+      <span
+        style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+      >
+        <span
+          style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+        >
+          <img
+            alt=""
+            aria-hidden="true"
+            src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%27400%27%20height=%27200%27/%3e"
+            style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+          />
+        </span>
+        <img
+          alt="Test Caption"
+          data-nimg="intrinsic"
+          decoding="async"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+          style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: cover; object-position: top;"
+        />
+        <noscript />
+      </span>
+    </div>
     <figcaption
       class="my-2 text-sm text-center text-light font-thin"
     >

--- a/components/Screenshots/__snapshots__/Screenshots.test.tsx.snap
+++ b/components/Screenshots/__snapshots__/Screenshots.test.tsx.snap
@@ -14,14 +14,34 @@ exports[`Screenshots component renders 1`] = `
       class="grid grid-cols-12 gap-4"
     >
       <figure
-        class="col-span-12 md:col-span-6 lg:col-span-4"
+        class="col-span-12 md:col-span-6 lg:col-span-4 relative"
       >
-        <img
-          alt="Image A"
-          class="cursor-pointer border-2 border-link hover:border-link-hover"
-          loading="lazy"
-          src="/#"
-        />
+        <div
+          class="cursor-pointer border-2 border-link hover:border-link-hover h-44 overflow-hidden"
+        >
+          <span
+            style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+          >
+            <span
+              style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%27400%27%20height=%27200%27/%3e"
+                style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+              />
+            </span>
+            <img
+              alt="Image A"
+              data-nimg="intrinsic"
+              decoding="async"
+              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+              style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: cover; object-position: top;"
+            />
+            <noscript />
+          </span>
+        </div>
         <figcaption
           class="my-2 text-sm text-center text-light font-thin"
         >
@@ -29,14 +49,34 @@ exports[`Screenshots component renders 1`] = `
         </figcaption>
       </figure>
       <figure
-        class="col-span-12 md:col-span-6 lg:col-span-4"
+        class="col-span-12 md:col-span-6 lg:col-span-4 relative"
       >
-        <img
-          alt="Image B"
-          class="cursor-pointer border-2 border-link hover:border-link-hover"
-          loading="lazy"
-          src="/#"
-        />
+        <div
+          class="cursor-pointer border-2 border-link hover:border-link-hover h-44 overflow-hidden"
+        >
+          <span
+            style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+          >
+            <span
+              style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%27400%27%20height=%27200%27/%3e"
+                style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+              />
+            </span>
+            <img
+              alt="Image B"
+              data-nimg="intrinsic"
+              decoding="async"
+              src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+              style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%; object-fit: cover; object-position: top;"
+            />
+            <noscript />
+          </span>
+        </div>
         <figcaption
           class="my-2 text-sm text-center text-light font-thin"
         >


### PR DESCRIPTION
# Description

Screenshots clickable image (not modal) now uses `next/image`.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings
