### PR TITLE
Fix bookmark labeller addon link

### DIFF
--- a/pages/projects/bookmark-labeller.tsx
+++ b/pages/projects/bookmark-labeller.tsx
@@ -1,6 +1,7 @@
 import { Divider } from '@components/Divider';
 import { ImageFigure } from '@components/ImageFigure';
 import { Layout } from '@components/Layout';
+import { Link } from '@components/Link';
 import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
@@ -9,7 +10,6 @@ import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
 import Image from 'next/image';
-import Link from 'next/link';
 import React from 'react';
 
 const BookmarkLabeller: React.FC<ProjectPageProps> = ({ images, project }) => (


### PR DESCRIPTION
# Description

The bookmark labeller addon link was not opening in a new tab. Switch from using `next/link` to the `Link` component.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings
