### PR TITLE
Migrated project card to next/image

### DIFF
--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -36,7 +36,7 @@ export const Nav: React.FC = () => {
     <nav className="leading-6 w-full absolute z-50">
       <div className="flex relative z-[200] items-center justify-between flex-wrap bg-nav text-white px-2">
         <div className="flex items-center flex-shrink-0 mr-6">
-          <div className="ml-6 w-8 h-8">
+          <div className="mx-6 w-8 h-8">
             <Image
               src="/favicon-32x32.png"
               alt="Website Logo"
@@ -45,9 +45,7 @@ export const Nav: React.FC = () => {
             />
           </div>
           <Link href="/">
-            <p className="ml-3">
-              <span className="text-xl tracking-normal">Kyle Gough</span>
-            </p>
+            <span className="text-xl tracking-normal">Kyle Gough</span>
           </Link>
         </div>
         <button

--- a/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Nav component renders 1`] = `
         class="flex items-center flex-shrink-0 mr-6"
       >
         <div
-          class="ml-6 w-8 h-8"
+          class="mx-6 w-8 h-8"
         >
           <img
             alt="Website Logo"
@@ -29,15 +29,11 @@ exports[`Nav component renders 1`] = `
         <a
           href="/"
         >
-          <p
-            class="ml-3"
+          <span
+            class="text-xl tracking-normal"
           >
-            <span
-              class="text-xl tracking-normal"
-            >
-              Kyle Gough
-            </span>
-          </p>
+            Kyle Gough
+          </span>
         </a>
       </div>
       <button

--- a/components/ProjectCard/ProjectCard.tsx
+++ b/components/ProjectCard/ProjectCard.tsx
@@ -3,6 +3,7 @@ import { ProjectChip } from '@components/ProjectChip';
 import { getFormattedDate, getShortDate } from '@utilities/date';
 import { Date } from '@utilities/types';
 import { clsx } from 'clsx';
+import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
 
@@ -33,7 +34,9 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
         )}
       >
         <FadeIn className={className}>
-          <img className="w-full" src={src} alt={alt} />
+          <div className="w-full">
+            <Image src={src} alt={alt} width={640} height={360} />
+          </div>
           <div className="text-white p-4 font-bold group-hover:brightness-125 group-focus:brightness-125 bg-nav-light">
             <div className="flex justify-between items-center">
               <p className="text-sm opacity-80">

--- a/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
+++ b/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
@@ -11,11 +11,21 @@ exports[`ProjectCard component renders 1`] = `
       <div
         class="opacity-0 transition-opacity duration-1000"
       >
-        <img
-          alt="Alt Text"
+        <div
           class="w-full"
-          src="/#image"
-        />
+        >
+          <img
+            alt="Alt Text"
+            data-nimg="1"
+            decoding="async"
+            height="360"
+            loading="lazy"
+            src="/_next/image?url=%2F%23image&w=1920&q=75"
+            srcset="/_next/image?url=%2F%23image&w=640&q=75 1x, /_next/image?url=%2F%23image&w=1920&q=75 2x"
+            style="color: transparent;"
+            width="640"
+          />
+        </div>
         <div
           class="text-white p-4 font-bold group-hover:brightness-125 group-focus:brightness-125 bg-nav-light"
         >

--- a/utilities/Project.ts
+++ b/utilities/Project.ts
@@ -109,7 +109,7 @@ export const projects: Project[] = [
         year: 2016,
       },
       end: {
-        month: 10,
+        month: 11,
         year: 2022,
       },
     },


### PR DESCRIPTION
# Description

- `ProjectCard` component uses `next/image`.
- Nav logo more margin on right side.
- Updated portfolio project date up to Nov 2022.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings
