### PR TITLE
ProjectCard with next/image and statically imported images

### DIFF
--- a/components/ProjectCard/ProjectCard.test.tsx
+++ b/components/ProjectCard/ProjectCard.test.tsx
@@ -10,7 +10,12 @@ describe('ProjectCard component', () => {
   it('renders', async () => {
     const { container } = render(
       <ProjectCard
-        src="/#image"
+        image={{
+          src: '/#image',
+          width: 100,
+          height: 100,
+          blurDataURL: '/#blur',
+        }}
         alt="Alt Text"
         date={{ month: 4, year: 2022 }}
         link="/#project"

--- a/components/ProjectCard/ProjectCard.tsx
+++ b/components/ProjectCard/ProjectCard.tsx
@@ -3,13 +3,13 @@ import { ProjectChip } from '@components/ProjectChip';
 import { getFormattedDate, getShortDate } from '@utilities/date';
 import { Date } from '@utilities/types';
 import { clsx } from 'clsx';
-import Image from 'next/image';
+import Image, { StaticImageData } from 'next/image';
 import Link from 'next/link';
 import React from 'react';
 
 interface ProjectCardProps {
   className?: string;
-  src: string;
+  image: StaticImageData;
   alt: string;
   date: Date;
   link: string;
@@ -18,7 +18,7 @@ interface ProjectCardProps {
 
 export const ProjectCard: React.FC<ProjectCardProps> = ({
   className,
-  src,
+  image,
   alt,
   date,
   link,
@@ -35,7 +35,14 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
       >
         <FadeIn className={className}>
           <div className="w-full">
-            <Image src={src} alt={alt} width={640} height={360} />
+            <Image
+              src={image.src}
+              alt={alt}
+              width={image.width}
+              height={image.height}
+              placeholder="blur"
+              blurDataURL={image.blurDataURL}
+            />
           </div>
           <div className="text-white p-4 font-bold group-hover:brightness-125 group-focus:brightness-125 bg-nav-light">
             <div className="flex justify-between items-center">

--- a/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
+++ b/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
@@ -18,12 +18,12 @@ exports[`ProjectCard component renders 1`] = `
             alt="Alt Text"
             data-nimg="1"
             decoding="async"
-            height="360"
+            height="100"
             loading="lazy"
-            src="/_next/image?url=%2F%23image&w=1920&q=75"
-            srcset="/_next/image?url=%2F%23image&w=640&q=75 1x, /_next/image?url=%2F%23image&w=1920&q=75 2x"
-            style="color: transparent;"
-            width="640"
+            src="/_next/image?url=%2F%23image&w=256&q=75"
+            srcset="/_next/image?url=%2F%23image&w=128&q=75 1x, /_next/image?url=%2F%23image&w=256&q=75 2x"
+            style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+            width="100"
           />
         </div>
         <div

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,6 +7,9 @@ import { Section } from '@components/Section';
 import { TimelineWidget } from '@components/TimelineWidget';
 import { useObserveElement } from '@hooks/useObserveElement';
 import { useTypewriter } from '@hooks/useTypewriter';
+import imageAISpaceTelescope from '@image/ai-space-telescope1.jpg';
+import imageCaveExploration from '@image/card-cave-exploration.jpg';
+import imageSudoku from '@image/card-sudoku.jpg';
 import { clsx } from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -54,7 +57,7 @@ const Home: React.FC = () => {
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mt-16 mb-8 px-4">
             <ProjectCard
-              src="/img/card-sudoku.jpg"
+              image={imageSudoku}
               alt="Logical Sudoku Solver Project Card"
               date={{
                 month: 1,
@@ -65,7 +68,7 @@ const Home: React.FC = () => {
             />
             <ProjectCard
               className="md:delay-100"
-              src="/img/ai-space-telescope1.jpg"
+              image={imageAISpaceTelescope}
               alt="AI Space Telescope Project Card"
               date={{
                 month: 11,
@@ -76,7 +79,7 @@ const Home: React.FC = () => {
             />
             <ProjectCard
               className="md:delay-200"
-              src="/img/card-cave-exploration.jpg"
+              image={imageCaveExploration}
               alt="Cave Exploration Project Card"
               date={{
                 month: 4,


### PR DESCRIPTION
# Description

`ProjectCard` uses `next/image` with statically imported images and blur placeholder.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings
