### PR TITLE
Statically import project images

### DIFF
--- a/components/Contact/Contact.test.tsx
+++ b/components/Contact/Contact.test.tsx
@@ -1,4 +1,4 @@
-import { mockIntersectionObserver } from '@mocks/mockIntersectionObserver';
+import mockIntersectionObserver from '@mocks/mockIntersectionObserver';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import axios from 'axios';
 import React from 'react';

--- a/components/FadeIn/FadeIn.test.tsx
+++ b/components/FadeIn/FadeIn.test.tsx
@@ -1,4 +1,4 @@
-import { mockIntersectionObserver } from '@mocks/mockIntersectionObserver';
+import mockIntersectionObserver from '@mocks/mockIntersectionObserver';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 

--- a/components/ImageFigure/ImageFigure.test.tsx
+++ b/components/ImageFigure/ImageFigure.test.tsx
@@ -1,3 +1,4 @@
+import mockStaticImageData from '@mocks/mockStaticImageData';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -6,7 +7,12 @@ import { ImageFigure } from './ImageFigure';
 describe('ImageFigure component', () => {
   it('renders', async () => {
     const { container } = render(
-      <ImageFigure image={{ src: '/#', alt: 'Test Caption' }} />
+      <ImageFigure
+        image={{
+          imageData: mockStaticImageData,
+          alt: 'Test Caption',
+        }}
+      />
     );
     expect(screen.getByText('Test Caption')).toBeVisible();
     expect(container).toMatchSnapshot();

--- a/components/ImageFigure/ImageFigure.tsx
+++ b/components/ImageFigure/ImageFigure.tsx
@@ -1,5 +1,5 @@
 import { Section } from '@components/Section';
-import { StaticImageData } from 'next/image';
+import Image, { StaticImageData } from 'next/image';
 import React from 'react';
 
 interface ImageFigureProps {
@@ -11,10 +11,14 @@ interface ImageFigureProps {
 
 export const ImageFigure: React.FC<ImageFigureProps> = ({ image }) => (
   <Section>
-    <img
+    <Image
       className="border-2 border-white rounded-lg text-center items-center shadow mx-auto"
       src={image.imageData.src}
       alt={image.alt}
+      width={image.imageData.width}
+      height={image.imageData.height}
+      placeholder="blur"
+      blurDataURL={image.imageData.blurDataURL}
     />
     <p className="mt-4 mb-2 text-sm text-center text-light font-thin">
       {image.alt}

--- a/components/ImageFigure/ImageFigure.tsx
+++ b/components/ImageFigure/ImageFigure.tsx
@@ -1,9 +1,10 @@
 import { Section } from '@components/Section';
+import { StaticImageData } from 'next/image';
 import React from 'react';
 
 interface ImageFigureProps {
   image: {
-    src: string;
+    imageData: StaticImageData;
     alt: string;
   };
 }
@@ -12,7 +13,7 @@ export const ImageFigure: React.FC<ImageFigureProps> = ({ image }) => (
   <Section>
     <img
       className="border-2 border-white rounded-lg text-center items-center shadow mx-auto"
-      src={image.src}
+      src={image.imageData.src}
       alt={image.alt}
     />
     <p className="mt-4 mb-2 text-sm text-center text-light font-thin">

--- a/components/ImageFigure/__snapshots__/ImageFigure.test.tsx.snap
+++ b/components/ImageFigure/__snapshots__/ImageFigure.test.tsx.snap
@@ -8,7 +8,14 @@ exports[`ImageFigure component renders 1`] = `
     <img
       alt="Test Caption"
       class="border-2 border-white rounded-lg text-center items-center shadow mx-auto"
-      src="/#"
+      data-nimg="1"
+      decoding="async"
+      height="100"
+      loading="lazy"
+      src="/_next/image?url=%2F%23image&w=256&q=75"
+      srcset="/_next/image?url=%2F%23image&w=128&q=75 1x, /_next/image?url=%2F%23image&w=256&q=75 2x"
+      style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+      width="100"
     />
     <p
       class="mt-4 mb-2 text-sm text-center text-light font-thin"

--- a/components/ImageModal/ImageModal.test.tsx
+++ b/components/ImageModal/ImageModal.test.tsx
@@ -1,3 +1,4 @@
+import mockStaticImageData from '@mocks/mockStaticImageData';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -5,13 +6,15 @@ import { ImageModal } from './ImageModal';
 
 describe('ImageModal component', () => {
   it('renders', async () => {
-    const { container } = render(<ImageModal src="/#" alt="Test Caption" />);
+    const { container } = render(
+      <ImageModal image={mockStaticImageData} alt="Test Caption" />
+    );
     expect(screen.getByText('Test Caption')).toBeVisible();
     expect(container).toMatchSnapshot();
   });
 
   it('dialog opens and closes on click', async () => {
-    render(<ImageModal src="/#" alt="Test Caption" />);
+    render(<ImageModal image={mockStaticImageData} alt="Test Caption" />);
     expect(screen.getByText('Test Caption')).toBeVisible();
 
     // Modal should not be in the document by default.

--- a/components/ImageModal/ImageModal.tsx
+++ b/components/ImageModal/ImageModal.tsx
@@ -1,11 +1,12 @@
+import Image, { StaticImageData } from 'next/image';
 import React, { useState } from 'react';
 
 interface ImageModalProps {
-  src: string;
+  image: StaticImageData;
   alt: string;
 }
 
-export const ImageModal: React.FC<ImageModalProps> = ({ src, alt }) => {
+export const ImageModal: React.FC<ImageModalProps> = ({ image, alt }) => {
   const [open, setOpen] = useState(false);
 
   const openModal = () => setOpen(true);
@@ -15,12 +16,15 @@ export const ImageModal: React.FC<ImageModalProps> = ({ src, alt }) => {
   return (
     <>
       <figure className="col-span-12 md:col-span-6 lg:col-span-6">
-        <img
-          loading="lazy"
+        <Image
           onClick={openModal}
           className="cursor-pointer border-2 border-link hover:border-link-hover"
-          src={src}
+          src={image.src}
           alt={alt}
+          width={image.width}
+          height={image.height}
+          placeholder="blur"
+          blurDataURL={image.blurDataURL}
         />
         <figcaption className="my-2 text-sm text-center text-light font-thin">
           {alt}
@@ -34,11 +38,14 @@ export const ImageModal: React.FC<ImageModalProps> = ({ src, alt }) => {
         >
           <div className="bg-white rounded shadow-lg">
             <div className="p-1 items-center justify-center text-center">
-              <img
-                loading="lazy"
+              <Image
                 className="text-center border-2 border-link max-w-full lg:max-w-screen-lg"
-                src={src}
+                src={image.src}
                 alt={alt}
+                width={image.width}
+                height={image.height}
+                placeholder="blur"
+                blurDataURL={image.blurDataURL}
               />
             </div>
             <div className="items-center text-center w-100 border-t p-3">

--- a/components/ImageModal/__snapshots__/ImageModal.test.tsx.snap
+++ b/components/ImageModal/__snapshots__/ImageModal.test.tsx.snap
@@ -8,8 +8,14 @@ exports[`ImageModal component renders 1`] = `
     <img
       alt="Test Caption"
       class="cursor-pointer border-2 border-link hover:border-link-hover"
+      data-nimg="1"
+      decoding="async"
+      height="100"
       loading="lazy"
-      src="/#"
+      src="/_next/image?url=%2F%23image&w=256&q=75"
+      srcset="/_next/image?url=%2F%23image&w=128&q=75 1x, /_next/image?url=%2F%23image&w=256&q=75 2x"
+      style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+      width="100"
     />
     <figcaption
       class="my-2 text-sm text-center text-light font-thin"

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -36,7 +36,7 @@ export const Nav: React.FC = () => {
     <nav className="leading-6 w-full absolute z-50">
       <div className="flex relative z-[200] items-center justify-between flex-wrap bg-nav text-white px-2">
         <div className="flex items-center flex-shrink-0 mr-6">
-          <div className="mx-6 w-8 h-8">
+          <div className="mx-5 w-8 h-8">
             <Image
               src="/favicon-32x32.png"
               alt="Website Logo"

--- a/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Nav component renders 1`] = `
         class="flex items-center flex-shrink-0 mr-6"
       >
         <div
-          class="mx-6 w-8 h-8"
+          class="mx-5 w-8 h-8"
         >
           <img
             alt="Website Logo"

--- a/components/ProjectCard/ProjectCard.test.tsx
+++ b/components/ProjectCard/ProjectCard.test.tsx
@@ -1,4 +1,4 @@
-import { mockIntersectionObserver } from '@mocks/mockIntersectionObserver';
+import mockIntersectionObserver from '@mocks/mockIntersectionObserver';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 

--- a/components/Screenshots/Screenshots.test.tsx
+++ b/components/Screenshots/Screenshots.test.tsx
@@ -1,3 +1,4 @@
+import mockStaticImageData from '@mocks/mockStaticImageData';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -8,8 +9,8 @@ describe('Screenshots component', () => {
     const { container } = render(
       <Screenshots
         images={[
-          { src: '/#', alt: 'Image A' },
-          { src: '/#', alt: 'Image B' },
+          { imageData: mockStaticImageData, alt: 'Image A' },
+          { imageData: mockStaticImageData, alt: 'Image B' },
         ]}
       />
     );

--- a/components/Screenshots/Screenshots.tsx
+++ b/components/Screenshots/Screenshots.tsx
@@ -1,10 +1,11 @@
 import { ImageModal } from '@components/ImageModal';
 import { Section } from '@components/Section';
+import { StaticImageData } from 'next/image';
 import React from 'react';
 
 interface ScreenshotProps {
   images: {
-    src: string;
+    imageData: StaticImageData;
     alt: string;
   }[];
 }
@@ -14,7 +15,7 @@ export const Screenshots: React.FC<ScreenshotProps> = ({ images }) => (
     <h2 className="text-3xl mb-12">Screenshots</h2>
     <div className="grid grid-cols-12 gap-4">
       {images.map((image, i) => {
-        return <ImageModal key={i} src={image.src} alt={image.alt} />;
+        return <ImageModal key={i} src={image.imageData.src} alt={image.alt} />;
       })}
     </div>
   </Section>

--- a/components/Screenshots/Screenshots.tsx
+++ b/components/Screenshots/Screenshots.tsx
@@ -15,7 +15,7 @@ export const Screenshots: React.FC<ScreenshotProps> = ({ images }) => (
     <h2 className="text-3xl mb-12">Screenshots</h2>
     <div className="grid grid-cols-12 gap-4">
       {images.map((image, i) => {
-        return <ImageModal key={i} src={image.imageData.src} alt={image.alt} />;
+        return <ImageModal key={i} image={image.imageData} alt={image.alt} />;
       })}
     </div>
   </Section>

--- a/components/Screenshots/__snapshots__/Screenshots.test.tsx.snap
+++ b/components/Screenshots/__snapshots__/Screenshots.test.tsx.snap
@@ -19,8 +19,14 @@ exports[`Screenshots component renders 1`] = `
         <img
           alt="Image A"
           class="cursor-pointer border-2 border-link hover:border-link-hover"
+          data-nimg="1"
+          decoding="async"
+          height="100"
           loading="lazy"
-          src="/#"
+          src="/_next/image?url=%2F%23image&w=256&q=75"
+          srcset="/_next/image?url=%2F%23image&w=128&q=75 1x, /_next/image?url=%2F%23image&w=256&q=75 2x"
+          style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+          width="100"
         />
         <figcaption
           class="my-2 text-sm text-center text-light font-thin"
@@ -34,8 +40,14 @@ exports[`Screenshots component renders 1`] = `
         <img
           alt="Image B"
           class="cursor-pointer border-2 border-link hover:border-link-hover"
+          data-nimg="1"
+          decoding="async"
+          height="100"
           loading="lazy"
-          src="/#"
+          src="/_next/image?url=%2F%23image&w=256&q=75"
+          srcset="/_next/image?url=%2F%23image&w=128&q=75 1x, /_next/image?url=%2F%23image&w=256&q=75 2x"
+          style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+          width="100"
         />
         <figcaption
           class="my-2 text-sm text-center text-light font-thin"

--- a/components/SkillList/SkillItem/SkillItem.test.tsx
+++ b/components/SkillList/SkillItem/SkillItem.test.tsx
@@ -1,4 +1,4 @@
-import { mockIntersectionObserver } from '@mocks/mockIntersectionObserver';
+import mockIntersectionObserver from '@mocks/mockIntersectionObserver';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 

--- a/components/TimelineWidget/TimelineNode/TimelineNode.test.tsx
+++ b/components/TimelineWidget/TimelineNode/TimelineNode.test.tsx
@@ -1,4 +1,4 @@
-import { mockIntersectionObserver } from '@mocks/mockIntersectionObserver';
+import mockIntersectionObserver from '@mocks/mockIntersectionObserver';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 

--- a/components/TimelineWidget/TimelineWidget.test.tsx
+++ b/components/TimelineWidget/TimelineWidget.test.tsx
@@ -1,4 +1,4 @@
-import { mockIntersectionObserver } from '@mocks/mockIntersectionObserver';
+import mockIntersectionObserver from '@mocks/mockIntersectionObserver';
 import { render } from '@testing-library/react';
 import React from 'react';
 

--- a/pages/projects/ai-space-telescope.tsx
+++ b/pages/projects/ai-space-telescope.tsx
@@ -5,6 +5,7 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageWebsite from '@image/ai-space-telescope1.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -54,7 +55,7 @@ const AISpaceTelescope: React.FC<ProjectPageProps> = ({ images, project }) => (
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
     {
-      src: '/img/ai-space-telescope1.jpg',
+      imageData: imageWebsite,
       alt: 'AI Space Telescope Website',
     },
   ];

--- a/pages/projects/bookmark-labeller.tsx
+++ b/pages/projects/bookmark-labeller.tsx
@@ -6,6 +6,8 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imagePopup from '@image/bookmark-labeller.jpg';
+import imageFolder from '@image/bookmark-labeller-folder.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -79,11 +81,11 @@ const BookmarkLabeller: React.FC<ProjectPageProps> = ({ images, project }) => (
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
     {
-      src: '/img/bookmark-labeller.jpg',
+      imageData: imagePopup,
       alt: 'Bookmark Labeller Extension Popup',
     },
     {
-      src: '/img/bookmark-labeller-folder.jpg',
+      imageData: imageFolder,
       alt: 'Labelled bookmark folder',
     },
   ];

--- a/pages/projects/bsplit.tsx
+++ b/pages/projects/bsplit.tsx
@@ -5,6 +5,11 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageBillList from '@image/bsplit1.jpg';
+import imageHompage from '@image/bsplit2.jpg';
+import imageNewBill from '@image/bsplit3.jpg';
+import imageGroupList from '@image/bsplit4.jpg';
+import imageNewGroup from '@image/bsplit5.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -54,11 +59,11 @@ const BSplit: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/bsplit1.jpg', alt: 'Bill list' },
-    { src: '/img/bsplit2.jpg', alt: 'Homepage' },
-    { src: '/img/bsplit3.jpg', alt: 'New bill form' },
-    { src: '/img/bsplit4.jpg', alt: 'Group list' },
-    { src: '/img/bsplit5.jpg', alt: 'New group form' },
+    { imageData: imageBillList, alt: 'Bill list' },
+    { imageData: imageHompage, alt: 'Homepage' },
+    { imageData: imageNewBill, alt: 'New bill form' },
+    { imageData: imageGroupList, alt: 'Group list' },
+    { imageData: imageNewGroup, alt: 'New group form' },
   ];
 
   return {

--- a/pages/projects/cave-exploration.tsx
+++ b/pages/projects/cave-exploration.tsx
@@ -5,6 +5,13 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageMultiDrone from '@image/cave-exploration1.jpg';
+import imageSingleDroneA from '@image/cave-exploration2.jpg';
+import imageSingleDroneB from '@image/cave-exploration3.jpg';
+import imageCaveGen1 from '@image/cave-generation1.png';
+import imageCaveGen2 from '@image/cave-generation2.png';
+import imageCaveGen3 from '@image/cave-generation3.png';
+import imageCaveGen4 from '@image/cave-generation4.png';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -76,21 +83,21 @@ const CaveExploration: React.FC<ProjectPageProps> = ({ images, project }) => (
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
     {
-      src: '/img/cave-exploration1.jpg',
+      imageData: imageMultiDrone,
       alt: 'Multiple drone cave exploration',
     },
     {
-      src: '/img/cave-exploration2.jpg',
+      imageData: imageSingleDroneA,
       alt: 'Single drone cave exploration',
     },
     {
-      src: '/img/cave-exploration3.jpg',
+      imageData: imageSingleDroneB,
       alt: 'Single drone cave exploration',
     },
-    { src: '/img/cave-generation1.png', alt: 'Cave generation step 1' },
-    { src: '/img/cave-generation2.png', alt: 'Cave generation step 2' },
-    { src: '/img/cave-generation3.png', alt: 'Cave generation step 3' },
-    { src: '/img/cave-generation4.png', alt: 'Cave generation step 4' },
+    { imageData: imageCaveGen1, alt: 'Cave generation step 1' },
+    { imageData: imageCaveGen2, alt: 'Cave generation step 2' },
+    { imageData: imageCaveGen3, alt: 'Cave generation step 3' },
+    { imageData: imageCaveGen4, alt: 'Cave generation step 4' },
   ];
 
   return {

--- a/pages/projects/cavern-minesweeper.tsx
+++ b/pages/projects/cavern-minesweeper.tsx
@@ -5,6 +5,8 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageFinishGame from '@image/cavern-minesweeper1.jpg';
+import imageStartGame from '@image/cavern-minesweeper2.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -50,8 +52,8 @@ const CavernMinesweeper: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/cavern-minesweeper1.jpg', alt: 'Finished game' },
-    { src: '/img/cavern-minesweeper2.jpg', alt: 'New game' },
+    { imageData: imageFinishGame, alt: 'Finished game' },
+    { imageData: imageStartGame, alt: 'New game' },
   ];
 
   return {

--- a/pages/projects/delivery-route-planner.tsx
+++ b/pages/projects/delivery-route-planner.tsx
@@ -5,6 +5,10 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageDeliveryView from '@image/delivery-route-planner1.jpg';
+import imageRouteView from '@image/delivery-route-planner2.jpg';
+import imageReport from '@image/delivery-route-planner3.jpg';
+import imageRoute from '@image/delivery-route-planner4.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -52,10 +56,10 @@ const DeliveryPlanner: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/delivery-route-planner1.jpg', alt: 'Delivery view' },
-    { src: '/img/delivery-route-planner2.jpg', alt: 'Route view' },
-    { src: '/img/delivery-route-planner3.jpg', alt: 'Generated report' },
-    { src: '/img/delivery-route-planner4.jpg', alt: 'Generated route' },
+    { imageData: imageDeliveryView, alt: 'Delivery view' },
+    { imageData: imageRouteView, alt: 'Route view' },
+    { imageData: imageReport, alt: 'Generated report' },
+    { imageData: imageRoute, alt: 'Generated route' },
   ];
 
   return {

--- a/pages/projects/graph-algorithm-visualiser.tsx
+++ b/pages/projects/graph-algorithm-visualiser.tsx
@@ -5,6 +5,11 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageNN2Opt from '@image/graph-algorithm-visualiser1.jpg';
+import imageNodes from '@image/graph-algorithm-visualiser2.jpg';
+import imageInfo from '@image/graph-algorithm-visualiser3.jpg';
+import imageGrahamScan from '@image/graph-algorithm-visualiser4.jpg';
+import imageRandomRoute from '@image/graph-algorithm-visualiser5.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -68,19 +73,19 @@ const GraphVisualiser: React.FC<ProjectPageProps> = ({ images, project }) => (
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
     {
-      src: '/img/graph-algorithm-visualiser1.jpg',
+      imageData: imageNN2Opt,
       alt: 'Nearest Neighbour with 2-Opt',
     },
     {
-      src: '/img/graph-algorithm-visualiser2.jpg',
+      imageData: imageNodes,
       alt: 'Randomly generated nodes',
     },
     {
-      src: '/img/graph-algorithm-visualiser3.jpg',
+      imageData: imageInfo,
       alt: 'Algorithm information',
     },
-    { src: '/img/graph-algorithm-visualiser4.jpg', alt: 'Graham Scan' },
-    { src: '/img/graph-algorithm-visualiser5.jpg', alt: 'Random route' },
+    { imageData: imageGrahamScan, alt: 'Graham Scan' },
+    { imageData: imageRandomRoute, alt: 'Random route' },
   ];
 
   return {

--- a/pages/projects/lucidlab.tsx
+++ b/pages/projects/lucidlab.tsx
@@ -5,6 +5,11 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageUploadTest from '@image/lucidlab1.jpg';
+import imageRSSI from '@image/lucidlab2.jpg';
+import imageCCA from '@image/lucidlab3.jpg';
+import imageUploadController from '@image/lucidlab4.jpg';
+import imageUploadImage from '@image/lucidlab5.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -73,11 +78,11 @@ const LucidLab: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/lucidlab1.jpg', alt: 'Upload test configuration page' },
-    { src: '/img/lucidlab4.jpg', alt: 'Upload IoT controller page' },
-    { src: '/img/lucidlab5.jpg', alt: 'Upload image page' },
-    { src: '/img/lucidlab2.jpg', alt: 'Mote RSSI Map' },
-    { src: '/img/lucidlab3.jpg', alt: 'Mote CCA Charts' },
+    { imageData: imageUploadTest, alt: 'Upload test configuration page' },
+    { imageData: imageUploadController, alt: 'Upload IoT controller page' },
+    { imageData: imageUploadImage, alt: 'Upload image page' },
+    { imageData: imageRSSI, alt: 'Mote RSSI Map' },
+    { imageData: imageCCA, alt: 'Mote CCA Charts' },
   ];
 
   return {

--- a/pages/projects/portfolio.tsx
+++ b/pages/projects/portfolio.tsx
@@ -6,6 +6,14 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageAbout from '@image/portfolio-about.jpg';
+import imageHomepage from '@image/portfolio-homepage.jpg';
+import imageShowcase from '@image/portfolio-project-showcase.jpg';
+import imageProjects from '@image/portfolio-projects.jpg';
+import imageV1Projects from '@image/portfolio-projects-v1a.jpg';
+import imageV1About from '@image/portfolio-projects-v1b.jpg';
+import imageV2Projects from '@image/portfolio-projects-v2.jpg';
+import imageV3Projects from '@image/portfolio-projects-v3.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -111,35 +119,35 @@ const Portfolio: React.FC<ProjectPageProps> = ({ images, project }) => (
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
     {
-      src: '/img/portfolio-projects-v1a.jpg',
+      imageData: imageV1Projects,
       alt: 'Portfolio project page version 1',
     },
     {
-      src: '/img/portfolio-projects-v1b.jpg',
+      imageData: imageV1About,
       alt: 'Portfolio about page version 1',
     },
     {
-      src: '/img/portfolio-projects-v2.jpg',
+      imageData: imageV2Projects,
       alt: 'Portfolio project page version 2',
     },
     {
-      src: '/img/portfolio-projects-v3.jpg',
+      imageData: imageV3Projects,
       alt: 'Portfolio project page version 3',
     },
     {
-      src: '/img/portfolio-homepage.jpg',
+      imageData: imageHomepage,
       alt: 'Current Portfolio Homepage',
     },
     {
-      src: '/img/portfolio-about.jpg',
+      imageData: imageAbout,
       alt: 'Current Portfolio About Page',
     },
     {
-      src: '/img/portfolio-projects.jpg',
+      imageData: imageProjects,
       alt: 'Current Portfolio Projects Page',
     },
     {
-      src: '/img/portfolio-project-showcase.jpg',
+      imageData: imageShowcase,
       alt: 'Current Portfolio Project Showcase',
     },
   ];

--- a/pages/projects/react-minesweeper.tsx
+++ b/pages/projects/react-minesweeper.tsx
@@ -4,6 +4,11 @@ import { Layout } from '@components/Layout';
 import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
+import imageComplete from '@image/react-minesweeper1.jpg';
+import imagePartial from '@image/react-minesweeper2.jpg';
+import imageLost from '@image/react-minesweeper3.jpg';
+import imageInitial from '@image/react-minesweeper4.jpg';
+import imageIntro from '@image/react-minesweeper5.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -34,14 +39,14 @@ const Minesweeper: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/react-minesweeper1.jpg', alt: 'Complete game' },
+    { imageData: imageComplete, alt: 'Complete game' },
     {
-      src: '/img/react-minesweeper2.jpg',
+      imageData: imagePartial,
       alt: 'Partially complete game',
     },
-    { src: '/img/react-minesweeper3.jpg', alt: 'Lost game' },
-    { src: '/img/react-minesweeper4.jpg', alt: 'Initial board' },
-    { src: '/img/react-minesweeper5.jpg', alt: 'App introduction' },
+    { imageData: imageLost, alt: 'Lost game' },
+    { imageData: imageInitial, alt: 'Initial board' },
+    { imageData: imageIntro, alt: 'App introduction' },
   ];
 
   return {

--- a/pages/projects/roller-coaster.tsx
+++ b/pages/projects/roller-coaster.tsx
@@ -5,6 +5,10 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageBackCart from '@image/roller-coaster1.jpg';
+import imageTracking from '@image/roller-coaster2.jpg';
+import imageCentreCart from '@image/roller-coaster3.jpg';
+import imageCloseup from '@image/roller-coaster4.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -50,10 +54,10 @@ const RollerCoaster: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/roller-coaster1.jpg', alt: 'Back cart camera view' },
-    { src: '/img/roller-coaster2.jpg', alt: 'Tracking camera view' },
-    { src: '/img/roller-coaster3.jpg', alt: 'Center cart camera view' },
-    { src: '/img/roller-coaster4.jpg', alt: 'Cart closeup' },
+    { imageData: imageBackCart, alt: 'Back cart camera view' },
+    { imageData: imageTracking, alt: 'Tracking camera view' },
+    { imageData: imageCentreCart, alt: 'Centre cart camera view' },
+    { imageData: imageCloseup, alt: 'Cart closeup' },
   ];
 
   return {

--- a/pages/projects/rscbot.tsx
+++ b/pages/projects/rscbot.tsx
@@ -5,6 +5,12 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageStockQuery from '@image/rscbot1.jpg';
+import imageNewsfeed from '@image/rscbot2.jpg';
+import imageFavourites from '@image/rscbot3.jpg';
+import imageNewsQuery from '@image/rscbot4.jpg';
+import imageOther from '@image/rscbot5.jpg';
+import imageHelp from '@image/rscbot6.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -56,15 +62,15 @@ const RSCBot: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/rscbot1.jpg', alt: 'Stock query' },
+    { imageData: imageStockQuery, alt: 'Stock query' },
     {
-      src: '/img/rscbot2.jpg',
+      imageData: imageNewsfeed,
       alt: 'Hourly newsfeed with natural language processing',
     },
-    { src: '/img/rscbot3.jpg', alt: 'Favourites selection' },
-    { src: '/img/rscbot4.jpg', alt: 'News query' },
-    { src: '/img/rscbot5.jpg', alt: 'Other queries' },
-    { src: '/img/rscbot6.jpg', alt: 'Help modal' },
+    { imageData: imageFavourites, alt: 'Favourites selection' },
+    { imageData: imageNewsQuery, alt: 'News query' },
+    { imageData: imageOther, alt: 'Other queries' },
+    { imageData: imageHelp, alt: 'Help modal' },
   ];
 
   return {

--- a/pages/projects/sorting-algorithm-visualiser.tsx
+++ b/pages/projects/sorting-algorithm-visualiser.tsx
@@ -5,6 +5,11 @@ import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
 import { VideoFigure } from '@components/VideoFigure';
+import imageUnsorted from '@image/sorting-algorithm-visualiser1.jpg';
+import imageRandom from '@image/sorting-algorithm-visualiser2.jpg';
+import imageBitonic from '@image/sorting-algorithm-visualiser3.jpg';
+import imagePoints from '@image/sorting-algorithm-visualiser4.jpg';
+import imageInfo from '@image/sorting-algorithm-visualiser5.jpg';
 import algorithms from '@utilities/algorithms.json';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
@@ -95,23 +100,23 @@ const SortingVisualiser: React.FC<ProjectPageProps> = ({ images, project }) => (
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
     {
-      src: '/img/sorting-algorithm-visualiser1.jpg',
+      imageData: imageUnsorted,
       alt: 'Unsorted Random Data',
     },
     {
-      src: '/img/sorting-algorithm-visualiser2.jpg',
+      imageData: imageRandom,
       alt: 'Random and sinusoidal datasets',
     },
     {
-      src: '/img/sorting-algorithm-visualiser3.jpg',
+      imageData: imageBitonic,
       alt: 'Bitonic sort and sorted dataset',
     },
     {
-      src: '/img/sorting-algorithm-visualiser4.jpg',
+      imageData: imagePoints,
       alt: 'Dataset visualised as points',
     },
     {
-      src: '/img/sorting-algorithm-visualiser5.jpg',
+      imageData: imageInfo,
       alt: 'Algorithm information table',
     },
   ];

--- a/pages/projects/sudoku.tsx
+++ b/pages/projects/sudoku.tsx
@@ -5,6 +5,8 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageExample1 from '@image/sudoku1.jpg';
+import imageExample2 from '@image/sudoku2.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -235,8 +237,8 @@ const Sudoku: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/sudoku1.jpg', alt: 'X-Wing example' },
-    { src: '/img/sudoku2.jpg', alt: 'XYZ-Wing example' },
+    { imageData: imageExample1, alt: 'X-Wing example' },
+    { imageData: imageExample2, alt: 'XYZ-Wing example' },
   ];
 
   return {

--- a/pages/projects/todo-list.tsx
+++ b/pages/projects/todo-list.tsx
@@ -5,6 +5,11 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageHomepage from '@image/todo-list1.jpg';
+import imageShopping from '@image/todo-list2.jpg';
+import imageRegistration from '@image/todo-list3.jpg';
+import imageLists from '@image/todo-list4.jpg';
+import imageLogin from '@image/todo-list5.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -49,11 +54,11 @@ const ToDoList: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/todo-list1.jpg', alt: 'Homepage' },
-    { src: '/img/todo-list2.jpg', alt: 'Shopping list' },
-    { src: '/img/todo-list3.jpg', alt: 'New user registration' },
-    { src: '/img/todo-list4.jpg', alt: "User's lists" },
-    { src: '/img/todo-list5.jpg', alt: 'Existing login page' },
+    { imageData: imageHomepage, alt: 'Homepage' },
+    { imageData: imageShopping, alt: 'Shopping list' },
+    { imageData: imageRegistration, alt: 'New user registration' },
+    { imageData: imageLists, alt: "User's lists" },
+    { imageData: imageLogin, alt: 'Existing login page' },
   ];
 
   return {

--- a/pages/projects/url-shortener.tsx
+++ b/pages/projects/url-shortener.tsx
@@ -5,6 +5,8 @@ import { Pagination } from '@components/Pagination';
 import { ProjectHeader } from '@components/ProjectHeader';
 import { Screenshots } from '@components/Screenshots';
 import { Section } from '@components/Section';
+import imageExample1 from '@image/url-shortener1.jpg';
+import imageExample2 from '@image/url-shortener2.jpg';
 import { getProjectData } from '@utilities/Project';
 import { ProjectPageProps } from '@utilities/types';
 import { GetStaticProps } from 'next';
@@ -50,8 +52,8 @@ const URLShortener: React.FC<ProjectPageProps> = ({ images, project }) => (
 
 export const getStaticProps: GetStaticProps = async () => {
   const images = [
-    { src: '/img/url-shortener1.jpg', alt: 'Shortened URL example 1' },
-    { src: '/img/url-shortener2.jpg', alt: 'Shortened URL example 2' },
+    { imageData: imageExample1, alt: 'Shortened URL example 1' },
+    { imageData: imageExample2, alt: 'Shortened URL example 2' },
   ];
 
   return {

--- a/utilities/mocks/mockIntersectionObserver.ts
+++ b/utilities/mocks/mockIntersectionObserver.ts
@@ -1,4 +1,4 @@
-export const mockIntersectionObserver = () => {
+const mockIntersectionObserver = () => {
   const mockIntersectionObserver = jest.fn();
   mockIntersectionObserver.mockReturnValue({
     observe: () => jest.fn(),
@@ -7,3 +7,5 @@ export const mockIntersectionObserver = () => {
   });
   window.IntersectionObserver = mockIntersectionObserver;
 };
+
+export default mockIntersectionObserver;

--- a/utilities/mocks/mockStaticImageData.ts
+++ b/utilities/mocks/mockStaticImageData.ts
@@ -1,0 +1,8 @@
+const mockStaticImageData = {
+  src: '/#image',
+  width: 100,
+  height: 100,
+  blurDataURL: '/#blur',
+};
+
+export default mockStaticImageData;

--- a/utilities/types.ts
+++ b/utilities/types.ts
@@ -45,7 +45,7 @@ export interface Skill {
 
 export interface ProjectPageProps {
   images: {
-    src: string;
+    image: StaticImageData;
     alt: string;
   }[];
   project: Project;

--- a/utilities/types.ts
+++ b/utilities/types.ts
@@ -45,7 +45,7 @@ export interface Skill {
 
 export interface ProjectPageProps {
   images: {
-    image: StaticImageData;
+    imageData: StaticImageData;
     alt: string;
   }[];
   project: Project;


### PR DESCRIPTION
# Description

- Statically import all project images.
- Update props of image components to use `StaticImageData` instead of `src`.
- Added `mockStaticImageData`.
- Updated snapshots.
- Reduced nav log horizontal margin.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings
