### PR TITLE
Statically import header image with next/image

### DIFF
--- a/components/Carousel/Carousel.test.tsx
+++ b/components/Carousel/Carousel.test.tsx
@@ -1,3 +1,4 @@
+import mockStaticImageData from '@mocks/mockStaticImageData';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -6,7 +7,9 @@ import { Carousel } from './Carousel';
 describe('Carousel component', () => {
   it('renders', async () => {
     const { container } = render(
-      <Carousel backgrounds={['bg-1', 'bg-2']}>Carousel Text</Carousel>
+      <Carousel backgrounds={[mockStaticImageData, mockStaticImageData]}>
+        Carousel Text
+      </Carousel>
     );
 
     expect(screen.getByText('Carousel Text')).toBeVisible();

--- a/components/Carousel/Carousel.tsx
+++ b/components/Carousel/Carousel.tsx
@@ -1,10 +1,11 @@
+import { StaticImageData } from 'next/image';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { CarouselImage } from './CarouselImage';
 
 interface CarouselProps {
   children: React.ReactNode;
-  backgrounds: string[];
+  backgrounds: StaticImageData[];
 }
 
 export const Carousel: React.FC<CarouselProps> = ({
@@ -30,7 +31,7 @@ export const Carousel: React.FC<CarouselProps> = ({
       <div className="absolute inset-0 bg-black opacity-70 w-full h-full z-10"></div>
       {backgrounds.map((image, index) => (
         <CarouselImage
-          key={`${image}_${index}`}
+          key={`${image.src}_${index}`}
           bg={image}
           show={carousel === index}
         />

--- a/components/Carousel/CarouselImage/CarouselImage.test.tsx
+++ b/components/Carousel/CarouselImage/CarouselImage.test.tsx
@@ -1,3 +1,4 @@
+import mockStaticImageData from '@mocks/mockStaticImageData';
 import { render } from '@testing-library/react';
 import React from 'react';
 
@@ -5,7 +6,9 @@ import { CarouselImage } from './CarouselImage';
 
 describe('CarouselImage component', () => {
   it('renders', async () => {
-    const { container } = render(<CarouselImage show={true} bg="bg-header1" />);
+    const { container } = render(
+      <CarouselImage show={true} bg={mockStaticImageData} />
+    );
     expect(container).toMatchSnapshot();
   });
 });

--- a/components/Carousel/CarouselImage/CarouselImage.tsx
+++ b/components/Carousel/CarouselImage/CarouselImage.tsx
@@ -1,21 +1,30 @@
 import { clsx } from 'clsx';
+import Image, { StaticImageData } from 'next/image';
 import React from 'react';
 
 interface CarouselImageProps {
   show: boolean;
-  bg: string;
+  bg: StaticImageData;
 }
 
 export const CarouselImage: React.FC<CarouselImageProps> = ({ show, bg }) => (
   <div
     className={clsx(
-      bg,
       { 'opacity-100': show },
       { 'opacity-0': !show },
       'absolute top-0 left-0',
-      'w-full h-full',
-      'bg-fixed bg-center bg-cover',
+      'w-full h-full clip-inset',
       'duration-2000 transition-opacity'
     )}
-  ></div>
+  >
+    <Image
+      src={bg.src}
+      alt=""
+      width={bg.width}
+      height={bg.height}
+      placeholder="blur"
+      blurDataURL={bg.blurDataURL}
+      className="fixed object-cover object-center w-full h-full"
+    />
+  </div>
 );

--- a/components/Carousel/CarouselImage/__snapshots__/CarouselImage.test.tsx.snap
+++ b/components/Carousel/CarouselImage/__snapshots__/CarouselImage.test.tsx.snap
@@ -3,7 +3,20 @@
 exports[`CarouselImage component renders 1`] = `
 <div>
   <div
-    class="bg-header1 opacity-100 absolute top-0 left-0 w-full h-full bg-fixed bg-center bg-cover duration-2000 transition-opacity"
-  />
+    class="opacity-100 absolute top-0 left-0 w-full h-full clip-inset duration-2000 transition-opacity"
+  >
+    <img
+      alt=""
+      class="fixed object-cover object-center w-full h-full"
+      data-nimg="1"
+      decoding="async"
+      height="100"
+      loading="lazy"
+      src="/_next/image?url=%2F%23image&w=256&q=75"
+      srcset="/_next/image?url=%2F%23image&w=128&q=75 1x, /_next/image?url=%2F%23image&w=256&q=75 2x"
+      style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+      width="100"
+    />
+  </div>
 </div>
 `;

--- a/components/Carousel/__snapshots__/Carousel.test.tsx.snap
+++ b/components/Carousel/__snapshots__/Carousel.test.tsx.snap
@@ -9,11 +9,37 @@ exports[`Carousel component renders 1`] = `
       class="absolute inset-0 bg-black opacity-70 w-full h-full z-10"
     />
     <div
-      class="bg-1 opacity-100 absolute top-0 left-0 w-full h-full bg-fixed bg-center bg-cover duration-2000 transition-opacity"
-    />
+      class="opacity-100 absolute top-0 left-0 w-full h-full clip-inset duration-2000 transition-opacity"
+    >
+      <img
+        alt=""
+        class="fixed object-cover object-center w-full h-full"
+        data-nimg="1"
+        decoding="async"
+        height="100"
+        loading="lazy"
+        src="/_next/image?url=%2F%23image&w=256&q=75"
+        srcset="/_next/image?url=%2F%23image&w=128&q=75 1x, /_next/image?url=%2F%23image&w=256&q=75 2x"
+        style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+        width="100"
+      />
+    </div>
     <div
-      class="bg-2 opacity-0 absolute top-0 left-0 w-full h-full bg-fixed bg-center bg-cover duration-2000 transition-opacity"
-    />
+      class="opacity-0 absolute top-0 left-0 w-full h-full clip-inset duration-2000 transition-opacity"
+    >
+      <img
+        alt=""
+        class="fixed object-cover object-center w-full h-full"
+        data-nimg="1"
+        decoding="async"
+        height="100"
+        loading="lazy"
+        src="/_next/image?url=%2F%23image&w=256&q=75"
+        srcset="/_next/image?url=%2F%23image&w=128&q=75 1x, /_next/image?url=%2F%23image&w=256&q=75 2x"
+        style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+        width="100"
+      />
+    </div>
     <div
       class="z-20 absolute inset-0 text-white mx-auto text-center flex tracking-tight items-center"
     >

--- a/components/TimelineWidget/TimelineNode/TimelineNode.test.tsx
+++ b/components/TimelineWidget/TimelineNode/TimelineNode.test.tsx
@@ -1,4 +1,5 @@
 import mockIntersectionObserver from '@mocks/mockIntersectionObserver';
+import mockStaticImageData from '@mocks/mockStaticImageData';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
@@ -14,7 +15,7 @@ describe('TimelineNode component', () => {
         subtitle="CEO"
         date="January 2000 - Present"
         align="left"
-        logo={{ src: '/#logo', width: 100, height: 100 }}
+        logo={mockStaticImageData}
       />
     );
     expect(screen.getByText('CEO')).toBeVisible();

--- a/components/TimelineWidget/TimelineNode/TimelineNode.tsx
+++ b/components/TimelineWidget/TimelineNode/TimelineNode.tsx
@@ -1,6 +1,6 @@
 import { FadeIn } from '@components/FadeIn';
 import { clsx } from 'clsx';
-import Image from 'next/image';
+import Image, { StaticImageData } from 'next/image';
 import React from 'react';
 
 interface TimelineNodeProps {
@@ -8,11 +8,7 @@ interface TimelineNodeProps {
   subtitle: string;
   date: string;
   align: 'left' | 'right';
-  logo: {
-    src: string;
-    width: number;
-    height: number;
-  };
+  logo: StaticImageData;
 }
 
 export const TimelineNode: React.FC<TimelineNodeProps> = ({
@@ -41,6 +37,8 @@ export const TimelineNode: React.FC<TimelineNodeProps> = ({
               alt={title}
               width={logo.width}
               height={logo.height}
+              placeholder="blur"
+              blurDataURL={logo.blurDataURL}
             />
           </div>
         </FadeIn>

--- a/components/TimelineWidget/TimelineNode/__snapshots__/TimelineNode.test.tsx.snap
+++ b/components/TimelineWidget/TimelineNode/__snapshots__/TimelineNode.test.tsx.snap
@@ -17,9 +17,9 @@ exports[`TimelineNode component renders 1`] = `
           decoding="async"
           height="100"
           loading="lazy"
-          src="/_next/image?url=%2F%23logo&w=256&q=75"
-          srcset="/_next/image?url=%2F%23logo&w=128&q=75 1x, /_next/image?url=%2F%23logo&w=256&q=75 2x"
-          style="color: transparent;"
+          src="/_next/image?url=%2F%23image&w=256&q=75"
+          srcset="/_next/image?url=%2F%23image&w=128&q=75 1x, /_next/image?url=%2F%23image&w=256&q=75 2x"
+          style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
           width="100"
         />
       </div>

--- a/components/TimelineWidget/TimelineWidget.tsx
+++ b/components/TimelineWidget/TimelineWidget.tsx
@@ -1,46 +1,43 @@
+import AtomLogo from '@image/atom.png';
+import BofaLogo from '@image/bofa.png';
 import { clsx } from 'clsx';
 import React from 'react';
 
 import { TimelineNode } from './TimelineNode';
 
-export const TimelineWidget: React.FC = () => {
-  const AtomLogo = { src: '/img/atom.png', width: 706, height: 192 };
-  const BofaLogo = { src: '/img/bofa.png', width: 602, height: 339 };
-
-  return (
-    <div
-      className={clsx(
-        'grid grid-cols-1 md:grid-cols-2',
-        'my-16 relative',
-        'before:absolute before:content-[""] before:h-2/4 before:w-[2px]',
-        'before:right-0 md:before:left-2/4',
-        'before:bg-gradient-to-t before:from-timeline before:via-timeline before:to-transparent',
-        'after:absolute after:content-[""] after:h-2/4 after:w-[2px]',
-        'after:top-2/4 after:right-0 md:after:left-2/4',
-        'after:bg-gradient-to-b after:from-timeline after:via-timeline after:to-transparent'
-      )}
-    >
-      <TimelineNode
-        title="Atom Learning"
-        subtitle="Front-End Engineer"
-        date="July 2022 - Present"
-        align="left"
-        logo={AtomLogo}
-      />
-      <TimelineNode
-        title="Bank of America"
-        subtitle="Tech Analyst"
-        date="July 2020 - June 2022"
-        align="right"
-        logo={BofaLogo}
-      />
-      <TimelineNode
-        title="Bank of America"
-        subtitle="Summer Intern"
-        date="June 2019 - August 2019"
-        align="left"
-        logo={BofaLogo}
-      />
-    </div>
-  );
-};
+export const TimelineWidget: React.FC = () => (
+  <div
+    className={clsx(
+      'grid grid-cols-1 md:grid-cols-2',
+      'my-16 relative',
+      'before:absolute before:content-[""] before:h-2/4 before:w-[2px]',
+      'before:right-0 md:before:left-2/4',
+      'before:bg-gradient-to-t before:from-timeline before:via-timeline before:to-transparent',
+      'after:absolute after:content-[""] after:h-2/4 after:w-[2px]',
+      'after:top-2/4 after:right-0 md:after:left-2/4',
+      'after:bg-gradient-to-b after:from-timeline after:via-timeline after:to-transparent'
+    )}
+  >
+    <TimelineNode
+      title="Atom Learning"
+      subtitle="Front-End Engineer"
+      date="July 2022 - Present"
+      align="left"
+      logo={AtomLogo}
+    />
+    <TimelineNode
+      title="Bank of America"
+      subtitle="Tech Analyst"
+      date="July 2020 - June 2022"
+      align="right"
+      logo={BofaLogo}
+    />
+    <TimelineNode
+      title="Bank of America"
+      subtitle="Summer Intern"
+      date="June 2019 - August 2019"
+      align="left"
+      logo={BofaLogo}
+    />
+  </div>
+);

--- a/components/TimelineWidget/__snapshots__/TimelineWidget.test.tsx.snap
+++ b/components/TimelineWidget/__snapshots__/TimelineWidget.test.tsx.snap
@@ -18,12 +18,12 @@ exports[`TimelineWidget component renders 1`] = `
             alt="Atom Learning"
             data-nimg="1"
             decoding="async"
-            height="192"
+            height="40"
             loading="lazy"
-            src="/_next/image?url=%2Fimg%2Fatom.png&w=1920&q=75"
-            srcset="/_next/image?url=%2Fimg%2Fatom.png&w=750&q=75 1x, /_next/image?url=%2Fimg%2Fatom.png&w=1920&q=75 2x"
-            style="color: transparent;"
-            width="706"
+            src="/_next/image?url=%2Fimg.jpg&w=96&q=75"
+            srcset="/_next/image?url=%2Fimg.jpg&w=48&q=75 1x, /_next/image?url=%2Fimg.jpg&w=96&q=75 2x"
+            style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+            width="40"
           />
         </div>
       </div>
@@ -67,12 +67,12 @@ exports[`TimelineWidget component renders 1`] = `
             alt="Bank of America"
             data-nimg="1"
             decoding="async"
-            height="339"
+            height="40"
             loading="lazy"
-            src="/_next/image?url=%2Fimg%2Fbofa.png&w=1920&q=75"
-            srcset="/_next/image?url=%2Fimg%2Fbofa.png&w=640&q=75 1x, /_next/image?url=%2Fimg%2Fbofa.png&w=1920&q=75 2x"
-            style="color: transparent;"
-            width="602"
+            src="/_next/image?url=%2Fimg.jpg&w=96&q=75"
+            srcset="/_next/image?url=%2Fimg.jpg&w=48&q=75 1x, /_next/image?url=%2Fimg.jpg&w=96&q=75 2x"
+            style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+            width="40"
           />
         </div>
       </div>
@@ -110,12 +110,12 @@ exports[`TimelineWidget component renders 1`] = `
             alt="Bank of America"
             data-nimg="1"
             decoding="async"
-            height="339"
+            height="40"
             loading="lazy"
-            src="/_next/image?url=%2Fimg%2Fbofa.png&w=1920&q=75"
-            srcset="/_next/image?url=%2Fimg%2Fbofa.png&w=640&q=75 1x, /_next/image?url=%2Fimg%2Fbofa.png&w=1920&q=75 2x"
-            style="color: transparent;"
-            width="602"
+            src="/_next/image?url=%2Fimg.jpg&w=96&q=75"
+            srcset="/_next/image?url=%2Fimg.jpg&w=48&q=75 1x, /_next/image?url=%2Fimg.jpg&w=96&q=75 2x"
+            style="color: transparent; background-size: cover; background-position: 50% 50%; background-repeat: no-repeat;"
+            width="40"
           />
         </div>
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,9 @@ import { useTypewriter } from '@hooks/useTypewriter';
 import imageAISpaceTelescope from '@image/ai-space-telescope1.jpg';
 import imageCaveExploration from '@image/card-cave-exploration.jpg';
 import imageSudoku from '@image/card-sudoku.jpg';
+import imageHeader1 from '@image/header1.jpg';
+import imageHeader2 from '@image/header2.jpg';
+import imageHeader3 from '@image/header3.jpg';
 import { clsx } from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -28,7 +31,7 @@ const Home: React.FC = () => {
     threshold: 0.5,
   });
 
-  const backgrounds = ['bg-header1', 'bg-header2', 'bg-header3'];
+  const backgrounds = [imageHeader1, imageHeader2, imageHeader3];
 
   return (
     <Layout title="Portfolio - Kyle Gough">

--- a/styles/tailwind.css
+++ b/styles/tailwind.css
@@ -29,3 +29,9 @@
     @apply ml-4;
   }
 }
+
+@layer utilities {
+  .clip-inset {
+    clip-path: inset(0);
+  }
+}


### PR DESCRIPTION
# Description

- Statically import header images.
- Convert header images from background URL to clipped image.
- Update components using `next/image` to use blur and correct types.
- Update snapshots.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings
