### PR TITLE
.prettierrc fix syntax error

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
   "tabWidth": 2,
-  "semi: true"
+  "semi": true
 }


### PR DESCRIPTION
# Description

Add missing double quote in `.prettierrc`. Honestly no idea how this went unnoticed for this long...

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have ensured the code follows the style guidelines of this project
- [x] I have added comments for new functionality
- [x] I have ensured the app builds without errors
- [x] I have ensured these changes create no new warnings
