### PR TITLE
Fix layout change

### DIFF
--- a/components/Hero/Hero.module.css
+++ b/components/Hero/Hero.module.css
@@ -1,10 +1,8 @@
 /* Hero: Falcon Heavy wireframe (Three.js) + copy */
 .slot {
   position: relative;
-  min-height: 88vh;
-  min-height: 88dvh;
-  /* Last wins: svh uses the small viewport and avoids resize jitter when browser chrome toggles. */
-  min-height: 88svh;
+  /* Stable baseline for browsers without svh support (avoid dynamic vh growth). */
+  min-height: 34rem;
   display: grid;
   grid-template-columns: 1fr;
   align-items: center;
@@ -12,6 +10,13 @@
   padding: 5rem 1.25rem 3.5rem;
   overflow: hidden;
   isolation: isolate;
+}
+
+@supports (height: 100svh) {
+  .slot {
+    /* Small viewport height prevents section gap growth while mobile chrome collapses. */
+    min-height: 88svh;
+  }
 }
 
 /*
@@ -96,11 +101,16 @@
   width: 100%;
   min-height: 12rem;
   aspect-ratio: 10 / 7;
-  max-height: min(70vh, 28rem);
-  max-height: min(70svh, 28rem);
+  max-height: 28rem;
   margin-inline: auto;
   /* No border or shadow: wireframe blends into space-gothic main */
   background: transparent;
+}
+
+@supports (height: 100svh) {
+  .rocketFrame {
+    max-height: min(70svh, 28rem);
+  }
 }
 
 .rocketCanvasHost {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that adjusts hero sizing rules; main risk is minor layout differences across browsers, especially on mobile viewports.
> 
> **Overview**
> Updates `Hero.module.css` to reduce mobile viewport-height “jitter” by replacing default `vh/dvh/svh` sizing with a fixed `min-height` baseline and applying `svh`-based sizing only behind `@supports`.
> 
> Similarly scopes `.rocketFrame` max-height to a stable default with an `svh`-aware override when supported, aiming to prevent layout shifts as browser chrome collapses/expands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b2daf188e6cd1adc2e8a28dfa4997d1f139dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->