### PR TITLE
Fix layout change

### DIFF
--- a/components/Hero/Hero.module.css
+++ b/components/Hero/Hero.module.css
@@ -12,13 +12,6 @@
   isolation: isolate;
 }
 
-@supports (height: 100svh) {
-  .slot {
-    /* Small viewport height prevents section gap growth while mobile chrome collapses. */
-    min-height: 88svh;
-  }
-}
-
 /*
  * Single-column hero: avoid stretching rows when min-height exceeds content — extra
  * space belongs below the copy. Otherwise vh/dvh changes while scrolling redistribute
@@ -105,12 +98,6 @@
   margin-inline: auto;
   /* No border or shadow: wireframe blends into space-gothic main */
   background: transparent;
-}
-
-@supports (height: 100svh) {
-  .rocketFrame {
-    max-height: min(70svh, 28rem);
-  }
 }
 
 .rocketCanvasHost {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CSS-only change confined to the Hero module, but it may slightly alter hero/rocket sizing on browsers that previously used `svh`-based max/min heights.
> 
> **Overview**
> Removes `@supports (height: 100svh)` overrides in `Hero.module.css` for both the hero `.slot` and `.rocketFrame`, relying on the fixed `rem`/`vh`-independent baseline sizing instead.
> 
> This prevents `svh`-driven min/max height adjustments that could cause layout shifts on mobile as the browser UI collapses/expands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79beba472bdce1ef00403a2f6c827e8ea966ade7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->